### PR TITLE
fix regex when checking containerd config.toml

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -60,7 +60,7 @@ jobs:
         run: ct lint --config ./.github/ct.yaml
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.7.0
+        uses: helm/kind-action@v1.8.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Add bitnami chart repos

--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,8 +3,8 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/Dragonfly2/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.0.3
-appVersion: 1.0.3
+version: 1.0.4
+appVersion: 1.0.4
 keywords:
   - dragonfly
   - d7y
@@ -28,6 +28,7 @@ annotations:
   artifacthub.io/changes: |
     - Update image version to v2.1.0-alpha.6.
     - Add redis configuration in scheduler.
+    - fix registries is http generate cert.d file name err
 
   artifacthub.io/links: |
     - name: Chart Source

--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,8 +3,8 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/Dragonfly2/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.0.3
-appVersion: 1.0.3
+version: 1.0.4
+appVersion: 1.0.4
 keywords:
   - dragonfly
   - d7y
@@ -26,6 +26,7 @@ sources:
 
 annotations:
   artifacthub.io/changes: |
+    - Update regex when checking containerd config.toml.
     - Update image version to v2.1.0-alpha.6.
     - Add redis configuration in scheduler.
 

--- a/charts/dragonfly/Chart.yaml
+++ b/charts/dragonfly/Chart.yaml
@@ -3,8 +3,8 @@ name: dragonfly
 description: Dragonfly is an intelligent P2P based image and file distribution system
 icon: https://raw.githubusercontent.com/dragonflyoss/Dragonfly2/main/docs/images/logo/dragonfly.svg
 type: application
-version: 1.0.4
-appVersion: 1.0.4
+version: 1.0.5
+appVersion: 1.0.5
 keywords:
   - dragonfly
   - d7y
@@ -27,8 +27,6 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - Update regex when checking containerd config.toml.
-    - Update image version to v2.1.0-alpha.6.
-    - Add redis configuration in scheduler.
 
   artifacthub.io/links: |
     - name: Chart Source

--- a/charts/dragonfly/templates/dfdaemon/dfdaemon-daemonset.yaml
+++ b/charts/dragonfly/templates/dfdaemon/dfdaemon-daemonset.yaml
@@ -374,7 +374,7 @@ spec:
                 need_restart=1
               fi
               {{- if .Values.containerRuntime.containerd.injectRegistryCredencials.enable}}
-              if grep "registry.config.\"$domain\".auth" $etcContainerd/{{ default "config.toml" .Values.containerRuntime.containerd.configFileName }}; then
+              if grep "registry.configs.\"$domain\".auth" $etcContainerd/{{ default "config.toml" .Values.containerRuntime.containerd.configFileName }}; then
                   echo "registry auth $registry found in {{ default "config.toml" .Values.containerRuntime.containerd.configFileName }}, skip"
               else
                 cat << EOF >> $etcContainerd/{{ default "config.toml" .Values.containerRuntime.containerd.configFileName }}
@@ -446,7 +446,7 @@ spec:
               need_restart=1
             fi
           {{- if .Values.containerRuntime.containerd.injectRegistryCredencials.enable}}
-            if grep "registry.config.\"$domain\".auth" $etcContainerd/{{ default "config.toml" .Values.containerRuntime.containerd.configFileName }}; then
+            if grep "registry.configs.\"$domain\".auth" $etcContainerd/{{ default "config.toml" .Values.containerRuntime.containerd.configFileName }}; then
                 echo "registry auth $registry found in {{ default "config.toml" .Values.containerRuntime.containerd.configFileName }}, skip"
             else
               cat << EOF >> $etcContainerd/{{ default "config.toml" .Values.containerRuntime.containerd.configFileName }}

--- a/charts/dragonfly/templates/dfdaemon/dfdaemon-daemonset.yaml
+++ b/charts/dragonfly/templates/dfdaemon/dfdaemon-daemonset.yaml
@@ -404,7 +404,7 @@ spec:
               mkdir -p $etcContainerd/certs.d
               for registry in $registries; do
                 # parse registry domain
-                domain=$(echo $registry | sed -e "s,http.://,," | sed "s,:.*,,")
+                domain=$(echo $registry | sed -e "s,http.*://,," | sed "s,:.*,,")
                 # inject registry
                 mkdir -p $etcContainerd/certs.d/$domain
                 if [[ -e "$etcContainerd/certs.d/$domain/hosts.toml" ]]; then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There is incorrect regex in dfdaemon-daemonset, when injecting registry auth into containerd config.toml, will generate duplicate entries, which leads to containerd down after changing config.toml

Fix the regex, then should be okay.

<!--- Describe your changes in detail -->



<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->



<!--- Why is this change required? What problem does it solve? -->
